### PR TITLE
fix: include raw response body in error description when status body is unparseable

### DIFF
--- a/pkg/grpc/gateway/request.go
+++ b/pkg/grpc/gateway/request.go
@@ -49,7 +49,7 @@ func DoRequest[T any](ctx context.Context, req *resty.Request) (*T, error) {
 		if err := status.ErrorProto(errRes); err != nil {
 			return nil, err
 		}
-		return nil, status.Error(HTTPStatusToCode(res.StatusCode()), errRes.String())
+		return nil, status.Error(HTTPStatusToCode(res.StatusCode()), res.String())
 	}
 
 	data, ok := res.Result().(*T)
@@ -136,7 +136,7 @@ func doHTTPRequest(ctx context.Context, req *resty.Request) (any, error) {
 		if err := status.ErrorProto(errRes); err != nil {
 			return nil, err
 		}
-		return nil, status.Error(HTTPStatusToCode(res.StatusCode()), errRes.String())
+		return nil, status.Error(HTTPStatusToCode(res.StatusCode()), res.String())
 	}
 	return &httpbody.HttpBody{
 		ContentType: res.Header().Get("Content-Type"),


### PR DESCRIPTION
## Summary

- When an HTTP error response has an empty body or a non-JSON `Content-Type` (e.g. an HTML page from a load balancer), resty leaves the `SetError(&rpcstatus.Status{})` destination at its zero value
- `status.ErrorProto` on a zero-value proto returns `nil` (code = OK), so execution falls through to `status.Error(HTTPStatusToCode(statusCode), errRes.String())`
- `errRes.String()` on a zero-value proto is always `""`, producing `"rpc error: code = X desc = "` with no diagnosable context
- Fix: use `res.String()` (the raw response body) instead of `errRes.String()`, so the error description contains whatever the server actually returned: `"rpc error: code = Unknown desc = <html>502 Bad Gateway</html>"`

Applies to both `DoRequest` and `doHTTPRequest`.

## Root cause detail

`parseResponseBody` in resty only attempts JSON unmarshal when `Content-Type` matches `(?i:(application|text)/(.*json.*)(;|$))`. A load balancer returning HTTP 500/503 with `text/html` or no `Content-Type` skips that path entirely, leaving `errRes` at zero value regardless of what was in the body.

## Test plan

- [x] `go test ./...` passes
- [ ] Verify that an HTTP 500 with an empty body now produces `"rpc error: code = Unknown desc = "` → `"rpc error: code = Unknown desc = <actual body>"` (or remains empty only if the body truly is empty)