### PR TITLE
fix: surface streaming errors faithfully (mid-stream on errCh + pre-first-message status)

### DIFF
--- a/internal/test/server/server.go
+++ b/internal/test/server/server.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/bufbuild/protoyaml-go"
 	"google.golang.org/genproto/googleapis/api/httpbody"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/akuity/grpc-gateway-client/internal/assets"
 	"github.com/akuity/grpc-gateway-client/internal/test/gen/testv1"
@@ -40,7 +42,7 @@ func (s *testServiceServer) SendInvitation(_ context.Context, req *testv1.SendIn
 	}, nil
 }
 
-func (s *testServiceServer) TrackInvitation(_ *testv1.TrackInvitationRequest, srv testv1.TestService_TrackInvitationServer) error {
+func (s *testServiceServer) TrackInvitation(req *testv1.TrackInvitationRequest, srv testv1.TestService_TrackInvitationServer) error {
 	eventTypes := []testv1.EventType{
 		testv1.EventType_EVENT_TYPE_SEEN,
 		testv1.EventType_EVENT_TYPE_ACCEPTED,
@@ -50,6 +52,12 @@ func (s *testServiceServer) TrackInvitation(_ *testv1.TrackInvitationRequest, sr
 			Type: et,
 		})
 		time.Sleep(100 * time.Millisecond)
+	}
+	// Used by tests to exercise a server stream that fails *after* emitting one
+	// or more results, which grpc-gateway frames as a terminal {"error": ...}
+	// SSE event.
+	if req.GetId() == "fail-after-events" {
+		return status.Error(codes.Internal, "boom")
 	}
 	return nil
 }

--- a/internal/test/server/server.go
+++ b/internal/test/server/server.go
@@ -43,6 +43,12 @@ func (s *testServiceServer) SendInvitation(_ context.Context, req *testv1.SendIn
 }
 
 func (s *testServiceServer) TrackInvitation(req *testv1.TrackInvitationRequest, srv testv1.TestService_TrackInvitationServer) error {
+	// Used by tests to exercise a server stream that fails *before* its first
+	// message. grpc-gateway writes this through the SSE marshaller too, so the
+	// HTTP error body is framed as `data: {"error": ...}`.
+	if req.GetId() == "fail-before-events" {
+		return status.Error(codes.NotFound, "nope")
+	}
 	eventTypes := []testv1.EventType{
 		testv1.EventType_EVENT_TYPE_SEEN,
 		testv1.EventType_EVENT_TYPE_ACCEPTED,

--- a/pkg/grpc/gateway/request.go
+++ b/pkg/grpc/gateway/request.go
@@ -105,6 +105,26 @@ func DoStreamingRequest[T any](ctx context.Context, c Client, req *resty.Request
 				errCh <- fmt.Errorf("unmarshal streaming response: %w", err)
 				return
 			}
+			// A server-streaming RPC that fails after emitting one or more
+			// results terminates the stream with a final {"error": <google.rpc.Status>}
+			// event. Surface it instead of skipping it; otherwise a truncated
+			// stream is indistinguishable from a successful one and the caller
+			// silently receives partial data.
+			if rawErr, ok := res[streamingResponseErrorKey]; ok {
+				var errResp rpcstatus.Status
+				if err := c.Unmarshal(rawErr, &errResp); err != nil {
+					errCh <- fmt.Errorf("unmarshal streaming error: %w", err)
+					return
+				}
+				if err := status.ErrorProto(&errResp); err != nil {
+					errCh <- err
+				} else {
+					// Defensive: an error event carrying an OK/empty status must
+					// still not read as a successful completion.
+					errCh <- errors.New("streaming response terminated with an error")
+				}
+				return
+			}
 			rawResult, ok := res[streamingResponseResultKey]
 			if !ok {
 				continue

--- a/pkg/grpc/gateway/request.go
+++ b/pkg/grpc/gateway/request.go
@@ -206,6 +206,14 @@ func wrapStreamingResponseError(c Client, resp *resty.Response) error {
 		return fmt.Errorf("read error response body: %w", err)
 	}
 
+	// A streaming handler that fails before its first message emits the error
+	// through the SSE marshaller, so the body is framed as `data: {"error":{...}}`.
+	// Strip that framing so the JSON underneath parses. This is a no-op for
+	// non-streaming (plain JSON) error bodies such as routing 404s, which start
+	// with '{' rather than the "data:" prefix.
+	data = bytes.TrimSpace(data)
+	data = bytes.TrimSpace(bytes.TrimPrefix(data, []byte("data:")))
+
 	var streamingResp streamingResponse
 	if err := json.Unmarshal(data, &streamingResp); err != nil {
 		return fmt.Errorf("unmarshal raw response: %w", err)

--- a/pkg/grpc/gateway/request_test.go
+++ b/pkg/grpc/gateway/request_test.go
@@ -133,6 +133,22 @@ read:
 	s.Require().Equal(codes.Internal, stat.Code())
 }
 
+func (s *RequestTestSuite) TestDoStreamingRequest_ErrorBeforeResults() {
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	// TrackInvitation fails before emitting any result. grpc-gateway sets the
+	// HTTP error status and writes the error through the SSE marshaller, so the
+	// body is framed as `data: {"error": ...}`. wrapStreamingResponseError must
+	// strip that framing and surface the real status, not collapse to Unknown.
+	req := s.client.NewRequest(http.MethodGet, "/invitation/fail-before-events")
+	_, _, err := gateway.DoStreamingRequest[testv1.TrackInvitationResponse](ctx, s.client, req)
+	s.Require().Error(err)
+	stat, ok := status.FromError(err)
+	s.Require().True(ok)
+	s.Require().Equal(codes.NotFound, stat.Code())
+}
+
 func (s *RequestTestSuite) TestDownloadRequest() {
 	ctx, cancel := context.WithTimeout(context.TODO(), 500*time.Millisecond)
 	defer cancel()

--- a/pkg/grpc/gateway/request_test.go
+++ b/pkg/grpc/gateway/request_test.go
@@ -96,6 +96,43 @@ func (s *RequestTestSuite) TestDoStreamingRequest() {
 	}
 }
 
+func (s *RequestTestSuite) TestDoStreamingRequest_ErrorAfterResults() {
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+
+	// TrackInvitation emits two results and then fails; grpc-gateway terminates
+	// the stream with a final {"error": ...} SSE event. That error must surface
+	// on errCh rather than being silently dropped, otherwise a truncated stream
+	// is indistinguishable from a successful one.
+	req := s.client.NewRequest(http.MethodGet, "/invitation/fail-after-events")
+	resCh, errCh, err := gateway.DoStreamingRequest[testv1.TrackInvitationResponse](ctx, s.client, req)
+	s.Require().NoError(err) // the stream starts 200 OK; the failure arrives mid-stream
+
+	var results int
+	var streamErr error
+read:
+	for {
+		select {
+		case <-ctx.Done():
+			s.FailNow("timed out; the terminal error was never delivered on errCh")
+		case e := <-errCh:
+			streamErr = e
+			break read
+		case _, ok := <-resCh:
+			if !ok {
+				break read // clean EOF; before the fix this is the (incorrect) path
+			}
+			results++
+		}
+	}
+
+	s.Require().Equal(2, results)
+	s.Require().Error(streamErr)
+	stat, ok := status.FromError(streamErr)
+	s.Require().True(ok)
+	s.Require().Equal(codes.Internal, stat.Code())
+}
+
 func (s *RequestTestSuite) TestDownloadRequest() {
 	ctx, cancel := context.WithTimeout(context.TODO(), 500*time.Millisecond)
 	defer cancel()


### PR DESCRIPTION
Two related fixes so streaming errors surface faithfully instead of being lost.
Both are in `DoStreamingRequest`'s error handling; neither requires a `go.mod`
change (`codes`/`status` come from the already-required `google.golang.org/grpc`),
and the full suite passes under the repo's CI Go 1.20 toolchain.

## 1. Mid-stream errors are swallowed (returned as silent success)

`DoStreamingRequest`'s decode loop only looks for the `result` key:

```go
rawResult, ok := res[streamingResponseResultKey] // "result"
if !ok { continue }
```

grpc-gateway frames a server-streaming RPC that fails **after** emitting one or
more results as a terminal `data: {"error": <google.rpc.Status>}` event. That
event has no `result` key, so the loop `continue`s past it, the next `Decode()`
returns `io.EOF`, and the goroutine `close(resCh)`s — so the caller sees a clean,
successful end-of-stream and **silently receives a truncated result**. The
`streamingResponseErrorKey` constant was defined but never consulted in the loop.

**Fix:** check for the `error` key before the `result` key; if present, unmarshal
the `google.rpc.Status` and deliver it on `errCh`. `resCh` is intentionally left
un-closed on this path so a consumer's `select` deterministically observes the
error rather than an EOF.

## 2. Pre-first-message errors collapse to `codes.Unknown`

When a streaming handler fails **before** its first message, grpc-gateway sets the
HTTP error status and writes the error through the SSE marshaller, so the body is
framed as `data: {"error": ...}`. `wrapStreamingResponseError` called
`json.Unmarshal` on the raw body, which fails on the `data:` prefix and returns a
generic error — so the real gRPC status (`NotFound`, `PermissionDenied`, …)
collapses to `codes.Unknown`.

**Fix:** strip the SSE `data:` framing before parsing. This is a no-op for
non-streaming (plain JSON) error bodies such as routing 404s, which start with
`{` rather than `data:`.

## Tests

- `TestDoStreamingRequest_ErrorAfterResults` — `result, result, error`: asserts both
  results are delivered and then the `Internal` status arrives on `errCh` (not a
  clean EOF).
- `TestDoStreamingRequest_ErrorBeforeResults` — SSE-framed pre-first-message error:
  asserts the returned error carries the real `NotFound` status, not `Unknown`.

Both were verified RED before their respective fix and GREEN after. The test
service's `TrackInvitation` gained two id-keyed hooks (`fail-after-events`,
`fail-before-events`); the existing streaming test is unchanged.

## Compatibility

`errCh` was already the loop's channel for decode/unmarshal errors, so callers
that drain it (the canonical `select { case <-resCh; case <-errCh }`) simply now
receive the real error instead of a truncated success. Fix (2) only changes the
initial error for SSE-framed bodies (`Unknown` → real code); it is a no-op for the
plain-JSON routing-404 case. No new contract for callers.
